### PR TITLE
Fix editor width in preview localhost being too large

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -155,11 +155,11 @@
       class="w-full max-w-[80rem] mt-4 flex justify-center items-center relative"
     >
       <div
-        class="w-[80rem] h-[600px] absolute border-6 border-gray-700 rounded-md top-0 left-0 z-20"
+        class="w-full max-w-[80rem] h-[600px] absolute border-6 border-gray-700 rounded-md top-0 left-0 z-20"
         bind:this={editorContainer}
       ></div>
       <div
-        class="w-[80rem] h-[600px] absolute border-6 border-gray-700 rounded-md top-0 left-0 z-10 opacity-50 z-[20] pointer-events-none"
+        class="w-full max-w-[80rem] h-[600px] absolute border-6 border-gray-700 rounded-md top-0 left-0 z-10 opacity-50 z-[20] pointer-events-none"
         bind:this={transparentEditorContainer}
       ></div>
     </div>


### PR DESCRIPTION
On my smaller screen, it looks like this:

<img width="2060" height="1524" alt="CleanShot 2025-12-26 at 17 19 03@2x" src="https://github.com/user-attachments/assets/6af6d109-fea9-4fd4-8d4c-ec9babb48ecd" />

With this PR, it looks better:

<img width="2056" height="1536" alt="CleanShot 2025-12-26 at 17 19 34@2x" src="https://github.com/user-attachments/assets/7a535753-0fc8-4dee-aee2-a7a576c4e390" />
